### PR TITLE
FIX heuristics config not loading

### DIFF
--- a/code/Seeder.php
+++ b/code/Seeder.php
@@ -55,9 +55,10 @@ class Seeder extends \Object
         $configParser = new ConfigParser($this->writer);
 
         $heuristics = array();
-        if ($this->config()->heuristics) {
+        $config = \Config::inst()->get('Seeder', 'heuristics');
+        if ($config) {
             $heuristicParser = new HeuristicParser();
-            $heuristics = $heuristicParser->parse($this->config()->heuristics);
+            $heuristics = $heuristicParser->parse($config);
         }
 
         if (is_array($dataObjects)) {


### PR DESCRIPTION
Heuristics aren't working at the moment because the config is stored under the class key `Seeder` not `Seeder\Seeder` which is what is returned by using `$this->config()`. Namespacing introduces a bit of a confusing config system eh? :)