### PR TITLE
FIX ensure arguments list is empty

### DIFF
--- a/code/Providers/Provider.php
+++ b/code/Providers/Provider.php
@@ -30,9 +30,11 @@ abstract class Provider extends \Object
     public static function parseOptions($argumentString)
     {
         $options = array();
-        $options['arguments'] = array_map(function ($arg) {
-            return trim($arg);
-        }, explode(',', $argumentString));
+        $options['arguments'] = (empty($argumentString))
+            ? null
+            : array_map(function ($arg) {
+                return trim($arg);
+            }, explode(',', $argumentString));
         return $options;
     }
 


### PR DESCRIPTION
If explode() fails to find a delimiter it returns an array containing the input string. In the case of a null/empty input string this lead to the arguments array containing a single null item when it should contain none, so Providers used an empty value for the first argument instead of the correct default.